### PR TITLE
[WIP] Correct upload URL

### DIFF
--- a/R/protobi.R
+++ b/R/protobi.R
@@ -33,7 +33,10 @@ protobi_put_data <- function(df, projectid, tablekey, apikey, host="https://app.
   on.exit(tryCatch(unlink(temp_path), error=function(e) {}))
 
   utils::write.csv(df, temp_path, na="", row.names=FALSE)
-  uri <- paste(host, "/api/v3/dataset/", projectid, "/data/", tablekey, "apiKey=", apikey, sep="")
+  uri <- paste0(
+    host, "/api/v3/dataset/", projectid, "/data/", tablekey,
+    "/csv?apiKey=", apikey
+  )
   httr::POST(uri, body=list(y=httr::upload_file(temp_path, "text/csv")))
 }
 


### PR DESCRIPTION
It looks like the current URI lacks `/csv` component:

> Upload data file
> - Method: POST
> - URL: //v3/datasets/:datasetId/data/:key/:type
> - @ param: datasetId unique identifier for dataset
> - @ param: key data key, e.g. 'main'

although the version we've used as the reference
https://github.com/protobi/protobi-r/blob/844eebd1bc31c0423d55886b4f161f57ef322fdc/R/protobi.R#L36

and [Node API](https://github.com/protobi/protobi-node-sdk/blob/61a8b7cbb1e9d6fee78752a70c38607207a5f220/js/protobi-rest-api.js#L80-L81) suggest rather missing parameter separator (`?`).

It is also worth pointing out that one of the previous versions used  `/csv` fragment

https://github.com/protobi/protobi-r/blob/0a121921c0681c42757b21bd9d71841accf4a18b/R/protobi.R#L25

CC @pietersv 