### PR TITLE
Add functions to access/edit properties and execute processes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,18 +1,24 @@
 Package: protobi
 Type: Package
 Title: Protobi R Library
-Version: 1.4
-Author: Ashwini Kumar, Pieter Sheth-Voss
+Version: 1.5
+Author: Ashwini Kumar, Pieter Sheth-Voss, Patrick Franco
 Maintainer: Protobi <support@protobi.com>
 Description: Utilities to get data and metadata from a Protobi project as an R Data Frame,
     apply variable labels as titles, apply value labels as factors, and send a new or revised R data frame to Protobi.
+    Additional utilities to access/edit project properties, execute data processes, and get a project's data tables.
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Imports:
+  dplyr,
   Hmisc,
   httr,
-  jsonlite
+  jsonlite,
+  purrr,
+  stringr,
+  tibble,
+  utils
 RoxygenNote: 6.1.1
 Suggests:
   testthat

--- a/R/protobi.R
+++ b/R/protobi.R
@@ -262,6 +262,7 @@ protobi_put_properties <- function(projectid, apikey, execkey, propertykeyvalue,
 
   if(!is.list(propertykeyvalue) | (is.list(propertykeyvalue) & length(names(propertykeyvalue)) == 0)) {stop("'propertykeyvalue' must be a named list")}
   if(purrr::pluck_depth(propertykeyvalue) > 2) {stop("'propertykeyvalue' cannot be a nested list")}
+  if(purrr::some(lengths(propertykeyvalue), function(x) x > 1)) {stop("'propertykeyvalue' must have only key value pairs; no list elements with multiple values")}
   if(purrr::some(propertykeyvalue, function(x) x == "" | is.null(x) | is.na(x))) {stop("'propertykeyvalue' cannot have blank, NULL, or NA values")}
   if(purrr::some(names(propertykeyvalue), function(x) x == "")) {stop("all 'propertykeyvalue' values must have an accompanying non-blank name")}
 
@@ -300,7 +301,7 @@ protobi_execute <- function(projectid, apikey, execkey, host = "https://app.prot
 
 #' Get data table details
 #'
-#' protobi_get_table_details() returns the names of all data tables associated with a Protobi project's schema (default) or primary-table.
+#' protobi_get_table_details() returns details of all data tables associated with a Protobi project's schema (default) or primary-table.
 #'
 #' @param projectid A character. Protobi project identifier.
 #' @param apikey A character. The APIKEY from your account profile, https://app.protobi.com/account.
@@ -308,7 +309,7 @@ protobi_execute <- function(projectid, apikey, execkey, host = "https://app.prot
 #' @param host URL, defaults to "https://v4.protobi.com"
 #' @param only_names TRUE/FALSE, defaults to FALSE. Use TRUE to return only data table names. Optionally use 'prune' in tandem to filter result.
 #' @param prune Optional stringr-formatted pattern. Pattern match data table names to remove from result. only_names must be TRUE to use.
-#' @return An httr response object
+#' @return An R data frame
 #' @export
 protobi_get_table_details <- function(projectid, apikey, scopekey = "schema", host = "https://v4.protobi.com", only_names = FALSE, prune = NULL) {
 
@@ -361,7 +362,7 @@ protobi_get_table_details <- function(projectid, apikey, scopekey = "schema", ho
     }
   }
 
-  output <- as_tibble(obj)
+  output <- tibble::as_tibble(obj)
 
   return(output)
 }

--- a/R/protobi.R
+++ b/R/protobi.R
@@ -191,7 +191,9 @@ protobi_get_url <- function(url) {
 #' @export
 protobi_put_url <- function(url) {
 
-  resp <- httr::PUT(url)
+  url_encoded <- utils::URLencode(url, reserved = FALSE, repeated = FALSE)
+
+  resp <- httr::PUT(url_encoded)
 
   httr::stop_for_status(resp, task = resp$url)
 

--- a/R/protobi.R
+++ b/R/protobi.R
@@ -330,14 +330,11 @@ protobi_get_table_details <- function(projectid, apikey, scopekey = "schema", ho
     cat("returning current tables in primaryTable", fill = TRUE)
     if (only_names) {cat(paste0("returning only table names; pruned: '", prune, "'"), fill = TRUE)}
     obj <- protobi_get_url(url)
-    obj <- dplyr::rename(obj, table_name = key)  #consistent naming
+    obj <- dplyr::rename(obj, table_name = key)
 
     if (only_names) {
-      # remove non-data objects
       obj <- dplyr::filter(obj, stringr::str_detect(type, "data"))
-      # keys
       obj <- dplyr::select(obj, table_name)
-      # optional pruning
       if(!is.null(prune)) {obj <- dplyr::filter(obj, !stringr::str_detect(table_name, prune))}
     }
   }
@@ -352,19 +349,17 @@ protobi_get_table_details <- function(projectid, apikey, scopekey = "schema", ho
     message(url)
     cat("returning all tables in schema", fill = TRUE)
     if (only_names) {cat(paste0("returning only table names; pruned: '", prune, "'"), fill = TRUE)}
+
     obj <- protobi_get_url(url)$rows
-    # remove hidden _keys and _rejects, user does not need
     obj <- dplyr::filter(obj, !stringr::str_detect(table_name, "_keys$|_rejects$"))
 
     if (only_names) {
-      # keys
       obj <- dplyr::select(obj, table_name)
-      # optional pruning
       if(!is.null(prune)) {obj <- dplyr::filter(obj, !stringr::str_detect(table_name, prune))}
     }
   }
 
-  output <- tibble::as_tibble(obj)
+  output <- as.data.frame(obj)
 
   return(output)
 }

--- a/R/protobi.R
+++ b/R/protobi.R
@@ -155,3 +155,213 @@ protobi_apply_titles <- function(df, titles) {
   }
   df
 }
+
+#' Get properties directly via URL as an R object
+#'
+#' protobi_get_url() returns a json-translated R object based on a user-supplied URL.
+#'
+#' @param url A character. URL location of requested properties.
+#' @keywords protobi
+#' @seealso [protobi_put_url()]
+#' @return An R list or character value object. Type dependent on properties requested.
+#' @export
+protobi_get_url <- function(url) {
+
+  resp <- httr::GET(url)
+
+  httr::stop_for_status(resp, task = resp$url)
+  if (!httr::has_content(resp)) {warning(paste("requested content is empty:", resp$url))}
+
+  con <- httr::content(resp, as = "text")
+  if (!jsonlite::validate(con)) {con <- jsonlite::toJSON(con)}
+  obj <- jsonlite::fromJSON(con)
+
+  return(obj)
+
+}
+
+#' Upload properties directly via URL
+#'
+#' protobi_put_url() uploads a key.value pair based on a user-supplied URL.
+#'
+#' @param url A character. URL location of requested properties.
+#' @keywords protobi
+#' @seealso [protobi_get_url()]
+#' @return An httr response object
+#' @export
+protobi_put_url <- function(url) {
+
+  resp <- httr::PUT(url)
+
+  httr::stop_for_status(resp, task = resp$url)
+
+  return(resp)
+
+}
+
+#' Get properties
+#'
+#' protobi_get_properties() dynamically gets all supplied properties from Protobi.
+#'
+#' @param projectid A character. Protobi project identifier.
+#' @param apikey A character. The APIKEY from your account profile, https://app.protobi.com/account.
+#' @param execkey A character. The key of your Protobi executable process.
+#' @param propertykey A character. Accepts valid (not blank, NULL, or NA) non-nested lists, vectors, or character values of property key(s). If not supplied, returns all properties.
+#' @param host URL, defaults to "https://app.protobi.com"
+#' @seealso [protobi_put_properties()]
+#' @return An R list or character value object. Type dependent on properties requested.
+#' @export
+protobi_get_properties <- function(projectid, apikey, execkey, propertykey = NULL, host = "https://app.protobi.com") {
+
+  if (is.null(propertykey)) {
+
+    url <- paste0(host, "/api/v3/dataset/", projectid, "/data/", execkey, "/properties", "?apiKey=", apikey)
+    message(url)
+    message("returning all properties")
+    obj <- protobi_get_url(url)
+
+  }
+
+  if(!is.null(propertykey)) {
+
+    if(is.list(propertykey) & purrr::pluck_depth(propertykey) > 2) {stop("'propertykey' cannot be a nested list")}
+    if(purrr::some(propertykey, function(x) x == "" | is.null(x) | is.na(x))) {stop("'propertykey' cannot have blank, NULL, or NA values")}
+
+    ls <- as.list(propertykey)
+    names(ls) <- propertykey
+
+    root <- paste0(host, "/api/v3/dataset/", projectid, "/data/", execkey, "/properties", "?apiKey=", apikey, "&key=")
+    dest <- paste(names(ls), "", sep=" ")
+    message(root)
+    message(dest)
+
+    ls <- purrr::map(ls, function(x) paste0(root, x))
+    obj <- purrr::map(ls, function(x) protobi_get_url(x))
+    obj <- purrr::list_flatten(obj, name_spec = "{outer}.{inner}")
+
+  }
+
+  return(obj)
+
+
+}
+
+#' Upload properties
+#'
+#' protobi_put_properties() dynamically uploads all supplied properties (as list key.value pairs) to Protobi.
+#'
+#' @param projectid A character. Protobi project identifier.
+#' @param apikey A character. The APIKEY from your account profile, https://app.protobi.com/account.
+#' @param execkey A character. The key of your Protobi executable process.
+#' @param propertykeyvalue A character. Accepts valid (not blank, NULL, or NA) non-nested named lists of property key.value pair(s).
+#' @param host URL, defaults to "https://app.protobi.com"
+#' @seealso [protobi_get_properties()]
+#' @return An httr response object
+#' @export
+protobi_put_properties <- function(projectid, apikey, execkey, propertykeyvalue, host = "https://app.protobi.com") {
+
+  if(!is.list(propertykeyvalue) | (is.list(propertykeyvalue) & length(names(propertykeyvalue)) == 0)) {stop("'propertykeyvalue' must be a named list")}
+  if(purrr::pluck_depth(propertykeyvalue) > 2) {stop("'propertykeyvalue' cannot be a nested list")}
+  if(purrr::some(propertykeyvalue, function(x) x == "" | is.null(x) | is.na(x))) {stop("'propertykeyvalue' cannot have blank, NULL, or NA values")}
+  if(purrr::some(names(propertykeyvalue), function(x) x == "")) {stop("all 'propertykeyvalue' values must have an accompanying non-blank name")}
+
+  root <- paste0(host, "/api/v3/dataset/", projectid, "/data/", execkey, "/properties", "?apiKey=", apikey, "&key=")
+  dest <- paste(names(propertykeyvalue), "", sep=" ")
+  message(root)
+  message(dest)
+
+  ls <- purrr::lmap(propertykeyvalue, function(x) list(paste0(root, names(x), "&value=", x)))
+
+  purrr::map(ls, function(x) protobi_put_url(x))
+
+}
+
+#' Execute process
+#'
+#' protobi_execute() executes a Protobi executable process.
+#'
+#' @param projectid A character. Protobi project identifier.
+#' @param apikey A character. The APIKEY from your account profile, https://app.protobi.com/account.
+#' @param execkey A character. The key of your Protobi executable process.
+#' @param host URL, defaults to "https://app.protobi.com"
+#' @return An httr response object
+#' @export
+protobi_execute <- function(projectid, apikey, execkey, host = "https://app.protobi.com") {
+
+  url <- paste0(host, "/api/v3/dataset/", projectid, "/data/", execkey, "/run", "?apiKey=", apikey)
+  message(url)
+
+  resp <- httr::PUT(url)
+  httr::stop_for_status(resp, task = resp$url)
+
+  return(resp)
+
+}
+
+#' Get data table details
+#'
+#' protobi_get_table_details() returns the names of all data tables associated with a Protobi project's schema (default) or primary-table.
+#'
+#' @param projectid A character. Protobi project identifier.
+#' @param apikey A character. The APIKEY from your account profile, https://app.protobi.com/account.
+#' @param scopekey A character. Defaults to "schema", can also be "primary". Gathers either all schema-table names or all primary-table names.
+#' @param host URL, defaults to "https://v4.protobi.com"
+#' @param only_names TRUE/FALSE, defaults to FALSE. Use TRUE to return only data table names. Optionally use 'prune' in tandem to filter result.
+#' @param prune Optional stringr-formatted pattern. Pattern match data table names to remove from result. only_names must be TRUE to use.
+#' @return An httr response object
+#' @export
+protobi_get_table_details <- function(projectid, apikey, scopekey = "schema", host = "https://v4.protobi.com", only_names = FALSE, prune = NULL) {
+
+  if (!scopekey %in% c("schema", "primary")) {stop("'scopekey' argument must be one of: 'schema' (default) or 'primary'")}
+  if (!is.null(prune) & !only_names) {stop("'prune' argument can only be used if 'only_names' = TRUE")}
+
+  if (scopekey == "primary") {
+
+    if(host != "https://app.protobi.com") {
+      host <- "https://app.protobi.com"
+      cat("switching host to https://app.protobi.com; v3 to access", scopekey, fill = TRUE)
+    }
+
+    url <- paste0(host, "/api/v3/", "dataset", "/", projectid, "/tables", "?apiKey=", apikey)
+    message(url)
+    cat("returning current tables in primaryTable", fill = TRUE)
+    if (only_names) {cat(paste0("returning only table names; pruned: '", prune, "'"), fill = TRUE)}
+    obj <- protobi_get_url(url)
+    obj <- dplyr::rename(obj, table_name = key)  #consistent naming
+
+    if (only_names) {
+      # remove non-data objects
+      obj <- dplyr::filter(obj, stringr::str_detect(type, "data"))
+      # keys
+      obj <- dplyr::select(obj, table_name)
+      # optional pruning
+      if(!is.null(prune)) {obj <- dplyr::filter(obj, !stringr::str_detect(table_name, prune))}
+    }
+  }
+
+  if (scopekey == "schema") {
+    if(host != "https://v4.protobi.com") {
+      host <- "https://v4.protobi.com"
+      cat("switching host to https://v4.protobi.com; v4 to access", scopekey, fill = TRUE)
+    }
+
+    url <- paste0(host, "/api/v4/", "project", "/", projectid, "/tables", "?apiKey=", apikey)
+    message(url)
+    cat("returning all tables in schema", fill = TRUE)
+    if (only_names) {cat(paste0("returning only table names; pruned: '", prune, "'"), fill = TRUE)}
+    obj <- protobi_get_url(url)$rows
+    # remove hidden _keys and _rejects, user does not need
+    obj <- dplyr::filter(obj, !stringr::str_detect(table_name, "_keys$|_rejects$"))
+
+    if (only_names) {
+      # keys
+      obj <- dplyr::select(obj, table_name)
+      # optional pruning
+      if(!is.null(prune)) {obj <- dplyr::filter(obj, !stringr::str_detect(table_name, prune))}
+    }
+  }
+
+  output <- as_tibble(obj)
+
+  return(output)
+}

--- a/protobi.Rproj
+++ b/protobi.Rproj
@@ -1,4 +1,4 @@
-Version: 1.3
+Version: 1.0
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
- protobi_get_url()
- protobi_put_url()
- protobi_get_properties()
- protobi_put_properties()
- protobi_execute()
- protobi_get_table_details()

Users directly access/edit properties manually using url() sub-functions. These functions do not have safeguards to prevent, for example, put_url() from overwriting an entire executable process. get_url() can gently handle empty content responses by warning but not stopping the process. put_url() can handle urls with special characters (including spaces) and encodes to prevent error. Advanced users could use these sub-functions. They provide cleaner functionality to the properties() functions and serve mainly to wrap the url into a httr request as well as manage json translation. 

properties() adds support to build url pathways, adds safeguards to ensure accurate key-value pairs, and allows for responsive get/put which can generate a large number of requests at once. The safeguards return user-friendly error messages. 

Users execute a data process with execute().

table_details() collect data tables associated with a project's schema or primarytable. It can return only data table names or all associated details from the request. Additional ability to prune data table names based on pattern match, allowing the user to quickly filter to relevant data tables if needed.

In general, these additional functions follow the established style of protobi-r functions by retaining the helpful console outputs and standard naming conventions of arguments like projectid, apikey, host, etc. The DESCRIPTION has been updated to include new package imports. No new content has been created for the README file, but that could be added later on.
